### PR TITLE
Add option to run nodes in standalone mode

### DIFF
--- a/src/goofi/connection.py
+++ b/src/goofi/connection.py
@@ -306,34 +306,3 @@ class IPCZeroMQConnection(ZeroMQConnection):
     @staticmethod
     def protocol() -> str:
         return "ipc"
-
-
-class DummyConnection(Connection):
-    """
-    A dummy connection that does not send or receive any data. This connection type is used
-    when using nodes in a standalone mode without the goofi-pipe manager.
-    """
-
-    def __init__(self) -> None:
-        # we don't call the parent constructor to avoid creating a a multiprocessing manager
-
-        from goofi.message import Message, MessageType
-
-        self.empty_msg = Message(MessageType.PING, {})
-
-    @staticmethod
-    def _create() -> Tuple[Connection, Connection]:
-        return DummyConnection(), DummyConnection()
-
-    def send(self, obj: object) -> None:
-        print("DUMMY SEND")
-
-    def recv(self) -> object:
-        print("DUMMY RECEIVE")
-        return self.empty_msg
-
-    def close(self) -> None:
-        pass
-
-    def __del__(self) -> None:
-        pass

--- a/src/goofi/connection.py
+++ b/src/goofi/connection.py
@@ -306,3 +306,34 @@ class IPCZeroMQConnection(ZeroMQConnection):
     @staticmethod
     def protocol() -> str:
         return "ipc"
+
+
+class DummyConnection(Connection):
+    """
+    A dummy connection that does not send or receive any data. This connection type is used
+    when using nodes in a standalone mode without the goofi-pipe manager.
+    """
+
+    def __init__(self) -> None:
+        # we don't call the parent constructor to avoid creating a a multiprocessing manager
+
+        from goofi.message import Message, MessageType
+
+        self.empty_msg = Message(MessageType.PING, {})
+
+    @staticmethod
+    def _create() -> Tuple[Connection, Connection]:
+        return DummyConnection(), DummyConnection()
+
+    def send(self, obj: object) -> None:
+        print("DUMMY SEND")
+
+    def recv(self) -> object:
+        print("DUMMY RECEIVE")
+        return self.empty_msg
+
+    def close(self) -> None:
+        pass
+
+    def __del__(self) -> None:
+        pass

--- a/src/goofi/data.py
+++ b/src/goofi/data.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import numpy as np
 
@@ -126,6 +126,27 @@ class Data:
             # make sure that table values are Data objects
             if not isinstance(value, Data):
                 raise ValueError(f"Expected table values of type Data, got {type(value)}.")
+
+
+def to_data(obj: Any, meta: Optional[Dict[str, Any]] = None):
+    """
+    Convert an object to a Data object. The data type of the Data object is determined by the type of the object.
+    The object must be of a supported type (i.e. numpy array, string, or dict).
+
+    ### Parameters
+    `obj` : Any
+        The object to convert to a Data object.
+    `meta` : Dict[str, Any], optional
+        The metadata dictionary.
+
+    ### Returns
+    Data
+        The converted Data object.
+    """
+    for dtype, types in DTYPE_TO_TYPE.items():
+        if isinstance(obj, types):
+            return Data(dtype=dtype, data=obj, meta=meta or {})
+    raise ValueError(f"Could not parse goofi dtype for object of type {type(obj)}.")
 
 
 DTYPE_TO_TYPE = {

--- a/src/goofi/node.py
+++ b/src/goofi/node.py
@@ -10,7 +10,7 @@ from threading import Event, Thread
 from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 from goofi import assets
-from goofi.connection import Connection
+from goofi.connection import Connection, DummyConnection
 from goofi.data import Data, DataType
 from goofi.message import Message, MessageType
 from goofi.node_helpers import InputSlot, NodeRef, OutputSlot
@@ -532,6 +532,20 @@ class Node(ABC):
             ),
             node,
         )
+
+    @classmethod
+    def create_standalone(cls) -> "Node":
+        """
+        Create a new node instance in the current process without a connection to the manager.
+
+        ### Returns
+        `Node`
+            The node instance.
+        """
+        # generate arguments for the node
+        in_slots, out_slots, params = cls._configure(cls)
+        # instantiate the node in the current process
+        return cls(DummyConnection(), in_slots, out_slots, params, True)
 
     @classmethod
     def category(cls) -> str:

--- a/src/goofi/node.py
+++ b/src/goofi/node.py
@@ -109,9 +109,10 @@ class Node(ABC):
         # set up dict of possibly timed out output connections
         self.pending_connections = {}
 
-        # initialize data processing thread
-        self.processing_thread = Thread(target=self._processing_loop, daemon=True)
-        self.processing_thread.start()
+        if environment != NodeEnv.STANDALONE:
+            # initialize data processing thread
+            self.processing_thread = Thread(target=self._processing_loop, daemon=True)
+            self.processing_thread.start()
 
         if environment == NodeEnv.MULTIPROCESSING:
             # this is a separate process, run the messaging loop in the current thread

--- a/src/goofi/node.py
+++ b/src/goofi/node.py
@@ -3,6 +3,7 @@ import time
 import traceback
 from abc import ABC, abstractmethod
 from copy import deepcopy
+from enum import Enum
 from multiprocessing import Process
 from os.path import dirname, join
 from pathlib import PosixPath
@@ -10,7 +11,7 @@ from threading import Event, Thread
 from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 from goofi import assets
-from goofi.connection import Connection, DummyConnection
+from goofi.connection import Connection
 from goofi.data import Data, DataType
 from goofi.message import Message, MessageType
 from goofi.node_helpers import InputSlot, NodeRef, OutputSlot
@@ -45,6 +46,16 @@ def require_init(func: Callable) -> Callable:
     return wrapper
 
 
+class NodeEnv(Enum):
+    """
+    Enumeration of the possible node environments.
+    """
+
+    MULTIPROCESSING = 1  # the node owns its own process
+    LOCAL = 2  # the node is running in the manager's process
+    STANDALONE = 3  # running in the main process, but without a manager
+
+
 class Node(ABC):
     """
     The base class for all nodes. A node is a processing unit that can receive data from other nodes, process the
@@ -63,8 +74,8 @@ class Node(ABC):
         are the output slots themselves.
     `params` : NodeParams
         An instance of the NodeParams class containing the parameters of the node.
-    `is_local` : bool
-        Whether the node is running in the same process as the manager.
+    `environment` : NodeEnv
+        The environment in which the node is running.
     """
 
     NO_MULTIPROCESSING = False
@@ -72,11 +83,11 @@ class Node(ABC):
 
     def __init__(
         self,
-        connection: Connection,
+        connection: Optional[Connection],
         input_slots: Dict[str, InputSlot],
         output_slots: Dict[str, OutputSlot],
         params: NodeParams,
-        is_local: bool,
+        environment: NodeEnv,
     ) -> None:
         # initialize the base class
         self._alive = True
@@ -88,7 +99,7 @@ class Node(ABC):
         self._output_slots = output_slots
         self._params = params
 
-        self._validate_attrs()
+        self._validate_attrs(environment)
 
         # initialize node flags
         self.process_flag = Event()
@@ -102,35 +113,47 @@ class Node(ABC):
         self.processing_thread = Thread(target=self._processing_loop, daemon=True)
         self.processing_thread.start()
 
-        if is_local:
-            # this is the main process, create a new thread to not block it
-            self.messaging_thread = Thread(target=self._messaging_loop, daemon=True)
-            self.messaging_thread.start()
-        else:
+        if environment == NodeEnv.MULTIPROCESSING:
             # this is a separate process, run the messaging loop in the current thread
             # NOTE: if we don't block the current thread, the node's process will die
             self._messaging_loop()
+        elif environment == NodeEnv.LOCAL:
+            # this is the main process, create a new thread to not block it
+            self.messaging_thread = Thread(target=self._messaging_loop, daemon=True)
+            self.messaging_thread.start()
+        elif environment == NodeEnv.STANDALONE:
+            # the node does not have a messaging, or processing loop when running in standalone mode
+            pass
+        else:
+            raise ValueError(f"Invalid environment: {environment}")
 
     @require_init
-    def _validate_attrs(self):
+    def _validate_attrs(self, environment: NodeEnv) -> None:
         """
         Check that all attributes are present and of the correct type.
         """
         # check connection type
-        if not isinstance(self.connection, Connection):
-            raise TypeError(f"Expected Connection, got {type(self.connection)}")
+        if environment == NodeEnv.STANDALONE:
+            if self.connection is not None:
+                raise ValueError("Running in standalone mode, connection should be None.")
+        else:
+            if not isinstance(self.connection, Connection):
+                raise TypeError(f"Expected Connection, got {type(self.connection)}")
+
         # check input slots type
         for name, slot in self._input_slots.items():
             if not isinstance(name, str) or len(name) == 0:
                 raise ValueError(f"Expected input slot name '{name}' to be a non-empty string.")
             if not isinstance(slot, InputSlot):
                 raise TypeError(f"Expected InputSlot for input slot '{name}', got {type(slot)}")
+
         # check output slots type
         for name, slot in self._output_slots.items():
             if not isinstance(name, str) or len(name) == 0:
                 raise ValueError(f"Expected output slot name '{name}' to be a non-empty string.")
             if not isinstance(slot, OutputSlot):
                 raise TypeError(f"Expected OutputSlot for output slot '{name}', got {type(slot)}")
+
         # check params type
         if not isinstance(self._params, NodeParams):
             raise TypeError(f"Expected NodeParams, got {type(self._params)}")
@@ -479,7 +502,7 @@ class Node(ABC):
                 conn1, conn2 = Connection.create()
 
                 # instantiate the node in a separate process
-                proc = Process(target=cls, args=(conn2, in_slots, out_slots, params, False), daemon=True)
+                proc = Process(target=cls, args=(conn2, in_slots, out_slots, params, NodeEnv.MULTIPROCESSING), daemon=True)
                 proc.start()
                 break
             except Exception as e:
@@ -520,7 +543,7 @@ class Node(ABC):
             params.update(initial_params)
         conn1, conn2 = Connection.create()
         # instantiate the node in the current process
-        node = cls(conn2, in_slots, out_slots, params, True)
+        node = cls(conn2, in_slots, out_slots, params, NodeEnv.LOCAL)
         # create the node reference
         return (
             NodeRef(
@@ -545,7 +568,7 @@ class Node(ABC):
         # generate arguments for the node
         in_slots, out_slots, params = cls._configure(cls)
         # instantiate the node in the current process
-        return cls(DummyConnection(), in_slots, out_slots, params, True)
+        return cls(None, in_slots, out_slots, params, NodeEnv.STANDALONE)
 
     @classmethod
     def category(cls) -> str:


### PR DESCRIPTION
This PR enables importing goofi nodes from any Python script and running them without starting the goofi-pipe manager.

Example using the embedding node:
```python
from goofi.data import to_data
from goofi.nodes.analysis.embedding import Embedding

if __name__ == "__main__":
    node = Embedding.create_standalone()
    node.params.embedding.split_by_comma.value = True
    node.setup()

    strings = "horse, donkey, cat, dog"
    output = node.process(text=to_data(strings), data=None)
    embeddings = output["text_embeddings"][0]

    print(embeddings)
```